### PR TITLE
[refactoring] argument parsing의 결과물로 구조체 CommandInfo 가 나오게 리팩토링

### DIFF
--- a/SSD/command_parser.cpp
+++ b/SSD/command_parser.cpp
@@ -1,4 +1,4 @@
-﻿#include "command_parser.h"
+#include "command_parser.h"
 
 
 CommandParser::CommandParser(int argc, char* argv[]) {
@@ -12,8 +12,8 @@ bool CommandParser::parse(int argc, char* argv[]) {
         std::cout << "  ssd.exe W [address] [data(hex)]" << std::endl;
         return false;
     }
-    command = argv[1];
-    address = std::stoi(argv[2]);
+    commandInfo.command = argv[1];
+    commandInfo.address = std::stoi(argv[2]);
 
     if (argc == 4)
     {
@@ -22,13 +22,11 @@ bool CommandParser::parse(int argc, char* argv[]) {
             std::cout << "Out of 4-byte range!" << std::endl;
             return false;
         }
-        data = std::stoul(argv[3], nullptr, 16);
+        commandInfo.data = std::stoul(argv[3], nullptr, 16);
     }
     return true;
        
 }
 
 bool CommandParser::isValid() const { return valid; }
-std::string CommandParser::getCommand() const { return command; }
-unsigned int CommandParser::getLBA() const { return address; }
-unsigned int CommandParser::getData() const { return data; }
+CommandInfo CommandParser::getCommandInfo() const{ return commandInfo; }

--- a/SSD/command_parser.h
+++ b/SSD/command_parser.h
@@ -4,20 +4,22 @@
 #include <cstdint>
 #include "util.h"
 
+struct CommandInfo {
+    std::string command;
+    unsigned int address;
+    unsigned int data;
+};
+
 class CommandParser {
 public:
-    CommandParser(int argc, char* argv[]);
+    CommandParser(int argc, char* argv[]);  
 
     bool isValid() const;
-    std::string getCommand() const;         // e.g. "W"
-    unsigned int getLBA() const;         // e.g. 0x10
-    unsigned int getData() const;        // e.g. 0xABCD1234
+    CommandInfo getCommandInfo() const;
 
 private:
     bool valid = false;
-    std::string command;
-    unsigned int address = 0;
-    unsigned int data = 0;
+    CommandInfo commandInfo;
 
     bool parse(int argc, char* argv[]);
 };

--- a/SSD/main.cpp
+++ b/SSD/main.cpp
@@ -57,16 +57,16 @@ int main(int argc, char* argv[]) {
 	CommandParser commandParser(argc, argv);
 	SSD ssd;
 
-	cout << "[logging] CMD :" << commandParser.getCommand() << endl;
+	cout << "[logging] CMD :" << commandParser.getCommandInfo().command << endl;
 	cout << "[logging] argc :" << argc << endl;
-	if (commandParser.getCommand() == "R") {
-		ssd.read(commandParser.getLBA());
+	if (commandParser.getCommandInfo().command == "R") {
+		ssd.read(commandParser.getCommandInfo().address);
 	}
-	else if (commandParser.getCommand() == "W") {
-		ssd.write(commandParser.getLBA(), commandParser.getData());
+	else if (commandParser.getCommandInfo().command == "W") {
+		ssd.write(commandParser.getCommandInfo().address, commandParser.getCommandInfo().data);
 	}
 	else {
-		cerr << "Unknown command: " << commandParser.getCommand() << endl;
+		cerr << "Unknown command: " << commandParser.getCommandInfo().command << endl;
 		return 1;
 	}
 

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -64,11 +64,12 @@ TEST(SsdTest, ValidReadCommandParsing)
 	std::vector<std::string> args = { "SSD.exe", "R", "1"};
 	std::vector<char*> argv;
 	for (auto& s : args) argv.push_back(const_cast<char*>(s.c_str()));
-	CommandParser parser(argv.size(), argv.data());
+	CommandParser parser(argv.size(), argv.data());	
+	CommandInfo commandInfo = parser.getCommandInfo();
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommandInfo().command, "R");
-	EXPECT_EQ(parser.getCommandInfo().address, 1);
+	EXPECT_EQ(commandInfo.command, "R");
+	EXPECT_EQ(commandInfo.address, 1);
 
 }
 TEST(SsdTest, InvalidLBAReadCommandParsing)
@@ -77,10 +78,11 @@ TEST(SsdTest, InvalidLBAReadCommandParsing)
 	std::vector<char*> argv;
 	for (auto& s : args) argv.push_back(const_cast<char*>(s.c_str()));
 	CommandParser parser(argv.size(), argv.data());
+	CommandInfo commandInfo = parser.getCommandInfo();
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommandInfo().command, "R");
-	EXPECT_EQ(parser.getCommandInfo().address, 1000);
+	EXPECT_EQ(commandInfo.command, "R");
+	EXPECT_EQ(commandInfo.address, 1000);
 
 }
 TEST(SsdTest, ValidWriteCommandParsing)
@@ -89,11 +91,12 @@ TEST(SsdTest, ValidWriteCommandParsing)
 	std::vector<char*> argv;
 	for (auto& s : args) argv.push_back(const_cast<char*>(s.c_str()));
 	CommandParser parser(argv.size(), argv.data());
+	CommandInfo commandInfo = parser.getCommandInfo();
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommandInfo().command, "W");
-	EXPECT_EQ(parser.getCommandInfo().address, 1);
-	EXPECT_EQ(parser.getCommandInfo().data, 0xFFFFFFFF);
+	EXPECT_EQ(commandInfo.command, "W");
+	EXPECT_EQ(commandInfo.address, 1);
+	EXPECT_EQ(commandInfo.data, 0xFFFFFFFF);
 
 }
 

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -67,8 +67,8 @@ TEST(SsdTest, ValidReadCommandParsing)
 	CommandParser parser(argv.size(), argv.data());
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommand(), "R");
-	EXPECT_EQ(parser.getLBA(), 1);
+	EXPECT_EQ(parser.getCommandInfo().command, "R");
+	EXPECT_EQ(parser.getCommandInfo().address, 1);
 
 }
 TEST(SsdTest, InvalidLBAReadCommandParsing)
@@ -79,8 +79,8 @@ TEST(SsdTest, InvalidLBAReadCommandParsing)
 	CommandParser parser(argv.size(), argv.data());
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommand(), "R");
-	EXPECT_EQ(parser.getLBA(), 1000);
+	EXPECT_EQ(parser.getCommandInfo().command, "R");
+	EXPECT_EQ(parser.getCommandInfo().address, 1000);
 
 }
 TEST(SsdTest, ValidWriteCommandParsing)
@@ -91,9 +91,9 @@ TEST(SsdTest, ValidWriteCommandParsing)
 	CommandParser parser(argv.size(), argv.data());
 
 	EXPECT_TRUE(parser.isValid());
-	EXPECT_EQ(parser.getCommand(), "W");
-	EXPECT_EQ(parser.getLBA(), 1);
-	EXPECT_EQ(parser.getData(), 0xFFFFFFFF);
+	EXPECT_EQ(parser.getCommandInfo().command, "W");
+	EXPECT_EQ(parser.getCommandInfo().address, 1);
+	EXPECT_EQ(parser.getCommandInfo().data, 0xFFFFFFFF);
 
 }
 


### PR DESCRIPTION
기존에 Command Parser가 들고 있고 getter함수를 통해 빼오던
address , command, data 를 구조체로 들고있게 만들었습니다.

다음 refactoring에서 SSD Controller 가 해당 구조체를 들고 가게 수정할 예정입니다. 