### PR TITLE
[refactoring] Device Controller class로 ssd 구동하게 refactoring

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -128,6 +128,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="command_parser.cpp" />
+    <ClCompile Include="device_controller.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ssd.cpp" />
     <ClCompile Include="ssd_test.cpp" />
@@ -138,6 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="command_parser.h" />
+    <ClInclude Include="device_controller.h" />
     <ClInclude Include="device.h" />
     <ClInclude Include="mock.h" />
     <ClInclude Include="ssd.h" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="command_parser.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="device_controller.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -51,6 +54,15 @@
       <Filter>소스 파일</Filter>
     </ClInclude>
     <ClInclude Include="command_parser.h">
+      <Filter>소스 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="device.h">
+      <Filter>소스 파일\헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="mock.h">
+      <Filter>소스 파일\헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="device_controller.h">
       <Filter>소스 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SSD/device_controller.cpp
+++ b/SSD/device_controller.cpp
@@ -1,0 +1,18 @@
+#include "device_controller.h"
+
+DeviceController::DeviceController(IDevice* device) : device_(device) { ; }
+
+int DeviceController::run(const CommandInfo& commandInfo) {
+    if (commandInfo.command == "W") {
+        device_->write(commandInfo.address, commandInfo.data);
+    }
+    else if (commandInfo.command == "R") {
+        unsigned int val = device_->read(commandInfo.address);
+        std::cout << "Read: 0x" << std::hex << val << "\n";
+    }
+    else {
+        std::cerr << "Invalid command\n";
+        return 1;
+    }
+    return 0;
+}

--- a/SSD/device_controller.cpp
+++ b/SSD/device_controller.cpp
@@ -3,16 +3,15 @@
 DeviceController::DeviceController(IDevice* device) : device_(device) { ; }
 
 int DeviceController::run(const CommandInfo& commandInfo) {
-    if (commandInfo.command == "W") {
-        device_->write(commandInfo.address, commandInfo.data);
-    }
-    else if (commandInfo.command == "R") {
-        unsigned int val = device_->read(commandInfo.address);
-        std::cout << "Read: 0x" << std::hex << val << "\n";
-    }
-    else {
-        std::cerr << "Invalid command\n";
-        return 1;
-    }
+	if (commandInfo.command == "R") {
+		device_->read(commandInfo.address);
+	}
+	else if (commandInfo.command == "W") {
+		device_->write(commandInfo.address, commandInfo.data);
+	}
+	else {
+		cerr << "Unknown command: " << commandInfo.command << endl;
+		return 1;
+	}
     return 0;
 }

--- a/SSD/device_controller.h
+++ b/SSD/device_controller.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "command_parser.h"
+#include "ssd.h"
+
+
+class DeviceController {
+public:
+    DeviceController(IDevice* device);
+    int run(const CommandInfo& commandInfo);
+private:
+    IDevice* device_; 
+};

--- a/SSD/main.cpp
+++ b/SSD/main.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "ssd.h"
 #include "command_parser.h"
+#include "device_controller.h"
 
 using namespace testing;
 using namespace std;
@@ -56,21 +57,13 @@ int main(int argc, char* argv[]) {
 
 	CommandParser commandParser(argc, argv);
 	SSD ssd;
+	CommandInfo commandinfo = commandParser.getCommandInfo();
+	DeviceController deviceController(&ssd);
 
 	cout << "[logging] CMD :" << commandParser.getCommandInfo().command << endl;
 	cout << "[logging] argc :" << argc << endl;
-	if (commandParser.getCommandInfo().command == "R") {
-		ssd.read(commandParser.getCommandInfo().address);
-	}
-	else if (commandParser.getCommandInfo().command == "W") {
-		ssd.write(commandParser.getCommandInfo().address, commandParser.getCommandInfo().data);
-	}
-	else {
-		cerr << "Unknown command: " << commandParser.getCommandInfo().command << endl;
-		return 1;
-	}
-
-	return 0;
+	
+	return deviceController.run(commandinfo);
 #endif
 }
 

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -2,6 +2,7 @@
 #include "ssd.h"
 #include "command_parser.h"
 #include "mock.h"
+#include "device_controller.h"
 
 using namespace testing;
 using namespace std;
@@ -108,4 +109,29 @@ TEST(SsdTest, InvalidWriteCommandParsing)
 	CommandParser parser(argv.size(), argv.data());
 
 	EXPECT_FALSE(parser.isValid());
+}
+
+TEST_F(SsdTestFixture, DeviceControllerValidWriteAndReadTest)
+{
+	std::vector<std::string> args = { "SSD.exe", "W", "1", "12345678" };
+	std::vector<char*> argv;
+	for (auto& s : args) argv.push_back(const_cast<char*>(s.c_str()));
+	CommandParser parser(argv.size(), argv.data());
+	CommandInfo commandInfo = parser.getCommandInfo();
+
+	DeviceController deviceController(&ssd);
+	
+	EXPECT_EQ(deviceController.run(commandInfo), 0);	// run 수행 결과 이상 없음 확인
+
+	args = { "SSD.exe", "R", "1" };  
+	argv.clear();
+	for (auto& s : args) argv.push_back(const_cast<char*>(s.c_str()));
+
+	CommandParser parser2(argv.size(), argv.data());
+	commandInfo = parser.getCommandInfo();
+
+	EXPECT_EQ(deviceController.run(commandInfo), 0);	// run 수행 결과 이상 없음 확인
+
+	
+
 }


### PR DESCRIPTION
device controller class를 만들고 main함수에서 controller.run() 과 같은 방식으로 ssd command가 수행되도록 refactoring 했습니다.

IDevice* 를 멤버로 가지고 있고 이를 통해 다른 device가 사용될 수 있도록 했습니다.
 