### PR TITLE
[refactoring] readCompare 에서 write를 분리함(재사용성 고려)

### DIFF
--- a/TestShell/TestScripts.cpp
+++ b/TestShell/TestScripts.cpp
@@ -2,6 +2,7 @@
 
 void TestScripts1::runTestScenario() {
 	for (int i = 0; i < MAX_LBA_NUM; i++) {
+		getShellDev()->write(i, i);
 		readCompare(i, i);
 	}
 }
@@ -10,10 +11,15 @@ void TestScripts2::runTestScenario() {
 	int loopCnt = 0;
 
 	for (loopCnt = 0; loopCnt < 30; loopCnt++) {
+		getShellDev()->write(4, 0x400);
 		readCompare(4, 0x400);
+		getShellDev()->write(0, 0x000);
 		readCompare(0, 0x000);
+		getShellDev()->write(3, 0x300);
 		readCompare(3, 0x300);
+		getShellDev()->write(1, 0x100);
 		readCompare(1, 0x100);
+		getShellDev()->write(2, 0x200);
 		readCompare(2, 0x200);
 	}
 }
@@ -32,8 +38,10 @@ void TestScripts3::runTestScenario() {
 	//TODO: Need to meet requirements
 	for (loopCnt = 0; loopCnt < 200; loopCnt++) {
 		randomVal = getRandomUint32();
+		getShellDev()->write(0, randomVal);
 		readCompare(0, randomVal);
 		randomVal = getRandomUint32();
+		getShellDev()->write(99, randomVal);
 		readCompare(99, randomVal);
 	}
 }

--- a/TestShell/TestScripts.h
+++ b/TestShell/TestScripts.h
@@ -33,7 +33,6 @@ public:
 	}
 
 	int readCompare(int lba, int data) {
-		getShellDev()->write(lba, data);
 
 		if (data != std::stoul(getShellDev()->read(lba), nullptr, 16)) {
 			testResult = TEST_FAIL;

--- a/TestShell/test_scripts.cpp
+++ b/TestShell/test_scripts.cpp
@@ -168,6 +168,7 @@ TEST_F(TestScriptsFixture, TestReadCompareDataMatch)
 		.WillOnce(testing::Return(ss.str()));
 
 	//Act
+	testScripts->getShellDev()->write(RAND_LBA, RAND_NUM);
 	int readCompareResult = testScripts->readCompare(RAND_LBA, RAND_NUM);
 
 	//Assert
@@ -186,6 +187,7 @@ TEST_F(TestScriptsFixture, TestReadCompareDataMisMatch)
 		.WillOnce(testing::Return("0xFFFFFFFF"));
 
 	//Act
+	testScripts->getShellDev()->write(RAND_LBA, RAND_NUM);
 	int readCompareResult = testScripts->readCompare(RAND_LBA, RAND_NUM);
 
 	//Assert


### PR DESCRIPTION
readCompare 는 이름 그대로 read와 compare만 수행해야 하는 것으로 보입니다.
write 를 분리하여 다른 test script에서도 사용할 수 있게 했습니다.(erase test)