### PR TITLE
[feat] buffer bug fix (can not parse unsigned int value in txt file)

### DIFF
--- a/SSD/buffer.cpp
+++ b/SSD/buffer.cpp
@@ -67,7 +67,7 @@ void Buffer::convertTxtToCmd(void) {
 			return;
 		}
 
-		cmdBuffer.push_back({ parts[1], stoi(parts[2]), (unsigned int)stoi(parts[3]) });
+		cmdBuffer.push_back({ parts[1], stoi(parts[2]), stoul(parts[3]) });
 	}
 }
 


### PR DESCRIPTION
txt 파일에서 마지막 인자에 int 양수값보다 큰 unsigned int 값이 들어갔을때 runtime 에러 발생하는 버그 수정